### PR TITLE
maybe we should specify the tag?

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -3,6 +3,8 @@ on:
     branches: ["main"]
   release:
     types: [published, edited, deleted, prereleased, released, created]
+    tags:
+      - "08-04-2023"
     
 permissions: write-all
   

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -2,7 +2,13 @@ on:
   push:
     branches: ["main"]
   release:
-    types: [published, edited, deleted, prereleased, released, created]
+    types:
+      - published
+      - edited
+      - deleted
+      - prereleased
+      - released
+      - created
     tags:
       - "08-04-2023"
     

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -9,8 +9,6 @@ on:
       - prereleased
       - released
       - created
-    tags:
-      - "08-04-2023"
     
 permissions: write-all
   

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches: ["main"]
   release:
-    types: [published, edited, deleted, prereleased, released]
+    types: [published, edited, deleted, prereleased, released, created]
     
 permissions: write-all
   


### PR DESCRIPTION
specified the "08-04-2023" tag (current release that files are being added to) in the workflow